### PR TITLE
added letter 'a' to 'past' on page 99

### DIFF
--- a/XML text
+++ b/XML text
@@ -461,9 +461,7 @@ of Sustenance; and intreated him to oblige 'em to eat, and assure 'em of their L
 <pb n="99" facs="tcp:51546:57"/>
 Injuries sustain'd by him. And they all, with one Accord, as<g ref="char:EOLhyphen"/>sur'd him, they cou'd not suffer enough, when it was for his Re<g ref="char:EOLhyphen"/>pose and Safety.</p>
             <p>After this they no longer re<g ref="char:EOLhyphen"/>fus'd to eat, but took what was brought 'em, and were pleas'd with their Captivity, since by it they hop'd to redeem the Prince, who, all the rest of the Voyage, was treated with all the Respect due to his Birth, though nothing cou'd divert his Melancholy; and he wou'd often sigh for <hi>Imoinda,</hi> and think this a Punishment due to his Misfortune, in having left that no<g ref="char:EOLhyphen"/>ble Maid behind him, that fatal Night, in the <hi>Otan,</hi> when he fled to the Camp.</p>
-            <p>Possess'd with a thousand Thoughts of p<gap reason="illegible" extent="1 letter">
-                  <desc>•</desc>
-               </gap>st Joys with this fair young Person, and a thousand
+            <p>Possess'd with a thousand Thoughts of past Joys with this fair young Person, and a thousand
 <pb n="100" facs="tcp:51546:58"/>
 Griefs for her eternal Loss, he en<g ref="char:EOLhyphen"/>dur'd a tedious Voyage, and at last arriv'd at the Mouth of the River of <hi>Surinam,</hi> a Colony be<g ref="char:EOLhyphen"/>longing to the King of <hi>England,</hi> and where they were to deliver some part of their Slaves. There the Merchants and Gentlemen of the Country going on Board, to demand those Lots of Slaves they had already agreed on; and, a<g ref="char:EOLhyphen"/>mongst those, the Over-seers of those Plantations where I then chanc'd to be, the Captain, who had given the Word, order'd his Men to bring up those noble Slaves in Fetters, whom I have spoken of; and having put 'em, some in one, and some in other Lots, with Women and Children (which they call <hi>Pickaninies,)</hi> they sold 'em off, as Slaves, to several Merchants and Gentlemen; not
 <pb n="101" facs="tcp:51546:58"/>


### PR DESCRIPTION
Due to the type damage on the original page, the letter 'a' in 'past' was unrecognizable.
